### PR TITLE
Helper scripts for ruby-runtime based assets

### DIFF
--- a/ruby-runtime/.bonsai.yml.example
+++ b/ruby-runtime/.bonsai.yml.example
@@ -1,0 +1,28 @@
+---
+description: "#{repo}"
+builds:
+- platform: "debian"
+  arch: "amd64"
+  asset_filename: "#{repo}_#{version}_debian_linux_amd64.tar.gz"
+  sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
+  filter:
+  -  "entity.system.os == 'linux'"
+  -  "entity.system.arch == 'amd64'"
+  -  "entity.system.platform == 'debian'"
+- platform: "centos"
+  arch: "amd64"
+  asset_filename: "#{repo}_#{version}_centos_linux_amd64.tar.gz"
+  sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
+  filter:
+  -  "entity.system.os == 'linux'"
+  -  "entity.system.arch == 'amd64'"
+  -  "entity.system.platform == 'rhel'"
+- platform: "alpine"
+  arch: "amd64"
+  asset_filename: "#{repo}_#{version}_alpine_linux_amd64.tar.gz"
+  sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
+  filter:
+  -  "entity.system.os == 'linux'"
+  -  "entity.system.arch == 'amd64'"
+  -  "entity.system.platform == 'alpine'"
+

--- a/ruby-runtime/Dockerfile.alpine
+++ b/ruby-runtime/Dockerfile.alpine
@@ -1,0 +1,15 @@
+FROM sensu/sensu-ruby-runtime:2.4.4-alpine as builder
+ARG ASSET_GEM
+ARG GIT_REF
+ARG GIT_REPO
+WORKDIR /assets/build/
+RUN apk add git
+RUN \
+  gem install --no-ri --no-doc bundler && \
+  printf "source 'https://rubygems.org'\n\ngem \"%s\", :git => \"%s\" , :ref => \"%s\"\n" ${ASSET_GEM} ${GIT_REPO} ${GIT_REF}| tee Gemfile 
+RUN bundle install --path=lib/ --binstubs=bin/ --standalone 
+RUN tar -czf /assets/${ASSET_GEM}.tar.gz -C /assets/build/ .
+
+FROM scratch
+ARG ASSET_GEM
+COPY --from=builder /assets/${ASSET_GEM}.tar.gz /

--- a/ruby-runtime/Dockerfile.centos
+++ b/ruby-runtime/Dockerfile.centos
@@ -1,0 +1,15 @@
+FROM sensu/sensu-ruby-runtime:2.4.4-centos as builder
+ARG ASSET_GEM
+ARG GIT_REF
+ARG GIT_REPO
+WORKDIR /assets/build/
+RUN yum install -y git 
+RUN \
+  gem install --no-ri --no-doc bundler && \
+  printf "source 'https://rubygems.org'\n\ngem \"%s\", :git => \"%s\" , :ref => \"%s\"\n" ${ASSET_GEM} ${GIT_REPO} ${GIT_REF}| tee Gemfile 
+RUN bundle install --path=lib/ --binstubs=bin/ --standalone 
+RUN tar -czf /assets/${ASSET_GEM}.tar.gz -C /assets/build/ .
+
+FROM scratch
+ARG ASSET_GEM
+COPY --from=builder /assets/${ASSET_GEM}.tar.gz /

--- a/ruby-runtime/Dockerfile.debian
+++ b/ruby-runtime/Dockerfile.debian
@@ -1,0 +1,15 @@
+FROM sensu/sensu-ruby-runtime:2.4.4-debian as builder
+ARG ASSET_GEM
+ARG GIT_REF
+ARG GIT_REPO
+WORKDIR /assets/build/
+RUN apt-get update && apt-get install -y git 
+RUN \
+  gem install --no-ri --no-doc bundler && \
+  printf "source 'https://rubygems.org'\n\ngem \"%s\", :git => \"%s\" , :ref => \"%s\"\n" ${ASSET_GEM} ${GIT_REPO} ${GIT_REF}| tee Gemfile 
+RUN bundle install --path=lib/ --binstubs=bin/ --standalone 
+RUN tar -czf /assets/${ASSET_GEM}.tar.gz -C /assets/build/ .
+
+FROM scratch
+ARG ASSET_GEM
+COPY --from=builder /assets/${ASSET_GEM}.tar.gz /

--- a/ruby-runtime/README.md
+++ b/ruby-runtime/README.md
@@ -2,6 +2,9 @@
 
 This directory contains helper scripts that can be used to automate Bonsai asset build as part of Sensu ruby plugin release process.
 
+### Bonsai 
+The provided Bonsai example configuration file `.bonsai.yml.example` defines Sensu assets for each of the supported ruby-runtime platforms.
+
 ### TravisCI Example Usage
 
 Make sure secure `GITHUB_TOKEN` is set travis environment.

--- a/ruby-runtime/README.md
+++ b/ruby-runtime/README.md
@@ -1,0 +1,32 @@
+## Bonsai CI helper scripts for ruby-runtime based assets
+
+This directory contains helper scripts that can be used to automate Bonsai asset build as part of Sensu ruby plugin release process.
+
+### TravisCI Example Usage
+
+Make sure secure `GITHUB_TOKEN` is set travis environment.
+
+Clone into bonsai directory `before_deploy`
+```
+before_deploy:
+  - git clone https://github.com/sensu/sensu-go-bonsai-asset.git --branch feature/ruby-plugin-assets bonsai
+```
+
+Create a deploy provider to run the travis build script
+```
+  - provider: script
+    script: bonsai/ruby-runtime/travis-build-bonsai-assets.sh sensu-plugins-disk-checks
+    skip_cleanup: true
+    on:
+      tags: true
+      all_branches: true
+      rvm: 2.4.1
+
+```
+
+#### Build script will:
+
+* builds bonsai assets tarballs
+* generate sha512 checksum file
+* upload bonsai assets into tagged github release
+

--- a/ruby-runtime/build-ruby-plugin-assets.sh
+++ b/ruby-runtime/build-ruby-plugin-assets.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+[[ -z "$GITHUB_TOKEN" ]] && { echo "GITHUB_TOKEN is empty" ; exit 1; }
+[[ -z "$1" ]] && { echo "Parameter 1, GEM_NAME is empty" ; exit 1; }
+[[ -z "$2" ]] && { echo "Parameter 2, GIT_OWNER_REPO is empty" ; exit 1; }
+[[ -z "$3" ]] && { echo "Parameter 3, GIT_REF is empty" ; exit 1; }
+
+GEM_NAME=$1
+GIT_OWNER_REPO=$2
+GIT_REF=$3
+GITHUB_RELEASE_TAG=$4
+TAG=$GITHUB_RELEASE_TAG
+[[ -z "$TAG" ]] && { echo "GITHUB_RELEASE_TAG is empty" ; TAG="0.0.1"; }
+echo $GEM_NAME $GIT_OWNER_REPO $TAG $GIT_REF
+
+mkdir dist
+GIT_REPO="https://github.com/${GIT_OWNER_REPO}.git"
+
+
+if [ -d dist ]; then
+  # Build Debian asset
+  docker build --build-arg "ASSET_GEM=${GEM_NAME}" --build-arg "GIT_REPO=${GIT_REPO}"  --build-arg "GIT_REF=${GIT_REF}" -t ruby-plugin-debian -f bonsai/Dockerfile.debian .
+  docker cp $(docker create --rm ruby-plugin-debian:latest sleep 0):/${GEM_NAME}.tar.gz ./dist/${GEM_NAME}_${TAG}_debian_linux_amd64.tar.gz
+
+  # Build Alpine asset
+  docker build --build-arg "ASSET_GEM=${GEM_NAME}" --build-arg "GIT_REPO=${GIT_REPO}"  --build-arg "GIT_REF=${GIT_REF}" -t ruby-plugin-alpine:latest -f bonsai/Dockerfile.alpine .
+  docker cp $(docker create --rm ruby-plugin-alpine:latest sleep 0):/${GEM_NAME}.tar.gz ./dist/${GEM_NAME}_${TAG}_alpine_linux_amd64.tar.gz
+
+  # Build CentOS asset
+  docker build --build-arg "ASSET_GEM=${GEM_NAME}" --build-arg "GIT_REPO=${GIT_REPO}"  --build-arg "GIT_REF=${GIT_REF}" -t ruby-plugin-centos:latest -f bonsai/Dockerfile.centos .
+  docker cp $(docker create --rm ruby-plugin-centos:latest sleep 0):/${GEM_NAME}.tar.gz ./dist/${GEM_NAME}_${TAG}_centos_linux_amd64.tar.gz
+
+  # Generate the sha512sum for all the assets
+  files=$( ls dist/*.tar.gz )
+  echo $files
+  for filename in $files; do
+    if [[ "$GITHUB_RELEASE_TAG" ]]; then
+      echo "upload $filename"
+      bonsai/github-release-upload.sh github_api_token=$GITHUB_TOKEN repo_slug="$GIT_OWNER_REPO" tag="${GITHUB_RELEASE_TAG}" filename="$filename"
+    fi
+  done 
+  file=$(basename "${files[0]}")
+  IFS=_ read -r package leftover <<< "$file"
+  unset leftover
+  if [ -n "$package" ]; then
+    echo "Generating sha512sum for ${package}"
+    cd dist || exit
+    sha512_file="${package}_${TAG}_sha512-checksums.txt"
+    #echo "${sha512_file}" > sha512_file
+    echo "sha512_file: ${sha512_file}"
+    sha512sum ./*.tar.gz > "${sha512_file}"
+    echo ""
+    cat "${sha512_file}"
+    cd ..
+    if [[ "$GITHUB_RELEASE_TAG" ]]; then
+      echo "upload ${sha512_file}"
+      bonsai/github-release-upload.sh github_api_token=$GITHUB_TOKEN repo_slug="$GIT_OWNER_REPO" tag="${GITHUB_RELEASE_TAG}" filename="dist/${sha512_file}"
+    fi
+  fi
+
+else
+  echo "error dist directory is missing"
+fi
+

--- a/ruby-runtime/build-ruby-plugin-assets.sh
+++ b/ruby-runtime/build-ruby-plugin-assets.sh
@@ -2,6 +2,7 @@
 ##
 # General asset build script
 ##
+WDIR="bonsai/ruby-runtime/"
 
 [[ -z "$GITHUB_TOKEN" ]] && { echo "GITHUB_TOKEN is empty" ; exit 1; }
 [[ -z "$1" ]] && { echo "Parameter 1, GEM_NAME is empty" ; exit 1; }
@@ -22,15 +23,15 @@ GIT_REPO="https://github.com/${GIT_OWNER_REPO}.git"
 
 if [ -d dist ]; then
   # Build Debian asset
-  docker build --build-arg "ASSET_GEM=${GEM_NAME}" --build-arg "GIT_REPO=${GIT_REPO}"  --build-arg "GIT_REF=${GIT_REF}" -t ruby-plugin-debian -f bonsai/Dockerfile.debian .
+  docker build --build-arg "ASSET_GEM=${GEM_NAME}" --build-arg "GIT_REPO=${GIT_REPO}"  --build-arg "GIT_REF=${GIT_REF}" -t ruby-plugin-debian -f ${WDIR}/Dockerfile.debian .
   docker cp $(docker create --rm ruby-plugin-debian:latest sleep 0):/${GEM_NAME}.tar.gz ./dist/${GEM_NAME}_${TAG}_debian_linux_amd64.tar.gz
 
   # Build Alpine asset
-  docker build --build-arg "ASSET_GEM=${GEM_NAME}" --build-arg "GIT_REPO=${GIT_REPO}"  --build-arg "GIT_REF=${GIT_REF}" -t ruby-plugin-alpine:latest -f bonsai/Dockerfile.alpine .
+  docker build --build-arg "ASSET_GEM=${GEM_NAME}" --build-arg "GIT_REPO=${GIT_REPO}"  --build-arg "GIT_REF=${GIT_REF}" -t ruby-plugin-alpine:latest -f ${WDIR}/Dockerfile.alpine .
   docker cp $(docker create --rm ruby-plugin-alpine:latest sleep 0):/${GEM_NAME}.tar.gz ./dist/${GEM_NAME}_${TAG}_alpine_linux_amd64.tar.gz
 
   # Build CentOS asset
-  docker build --build-arg "ASSET_GEM=${GEM_NAME}" --build-arg "GIT_REPO=${GIT_REPO}"  --build-arg "GIT_REF=${GIT_REF}" -t ruby-plugin-centos:latest -f bonsai/Dockerfile.centos .
+  docker build --build-arg "ASSET_GEM=${GEM_NAME}" --build-arg "GIT_REPO=${GIT_REPO}"  --build-arg "GIT_REF=${GIT_REF}" -t ruby-plugin-centos:latest -f ${WDIR}/Dockerfile.centos .
   docker cp $(docker create --rm ruby-plugin-centos:latest sleep 0):/${GEM_NAME}.tar.gz ./dist/${GEM_NAME}_${TAG}_centos_linux_amd64.tar.gz
 
   # Generate the sha512sum for all the assets

--- a/ruby-runtime/build-ruby-plugin-assets.sh
+++ b/ruby-runtime/build-ruby-plugin-assets.sh
@@ -2,7 +2,7 @@
 ##
 # General asset build script
 ##
-WDIR="bonsai/ruby-runtime/"
+[[ -z "$WDIR" ]] && { echo "WDIR is empty using bonsai/" ; WDIR="bonsai/"; }
 
 [[ -z "$GITHUB_TOKEN" ]] && { echo "GITHUB_TOKEN is empty" ; exit 1; }
 [[ -z "$1" ]] && { echo "Parameter 1, GEM_NAME is empty" ; exit 1; }
@@ -23,15 +23,15 @@ GIT_REPO="https://github.com/${GIT_OWNER_REPO}.git"
 
 if [ -d dist ]; then
   # Build Debian asset
-  docker build --build-arg "ASSET_GEM=${GEM_NAME}" --build-arg "GIT_REPO=${GIT_REPO}"  --build-arg "GIT_REF=${GIT_REF}" -t ruby-plugin-debian -f ${WDIR}/Dockerfile.debian .
+  docker build --build-arg "ASSET_GEM=${GEM_NAME}" --build-arg "GIT_REPO=${GIT_REPO}"  --build-arg "GIT_REF=${GIT_REF}" -t ruby-plugin-debian -f ${WDIR}/ruby-runtime/Dockerfile.debian .
   docker cp $(docker create --rm ruby-plugin-debian:latest sleep 0):/${GEM_NAME}.tar.gz ./dist/${GEM_NAME}_${TAG}_debian_linux_amd64.tar.gz
 
   # Build Alpine asset
-  docker build --build-arg "ASSET_GEM=${GEM_NAME}" --build-arg "GIT_REPO=${GIT_REPO}"  --build-arg "GIT_REF=${GIT_REF}" -t ruby-plugin-alpine:latest -f ${WDIR}/Dockerfile.alpine .
+  docker build --build-arg "ASSET_GEM=${GEM_NAME}" --build-arg "GIT_REPO=${GIT_REPO}"  --build-arg "GIT_REF=${GIT_REF}" -t ruby-plugin-alpine:latest -f ${WDIR}/ruby-runtime/Dockerfile.alpine .
   docker cp $(docker create --rm ruby-plugin-alpine:latest sleep 0):/${GEM_NAME}.tar.gz ./dist/${GEM_NAME}_${TAG}_alpine_linux_amd64.tar.gz
 
   # Build CentOS asset
-  docker build --build-arg "ASSET_GEM=${GEM_NAME}" --build-arg "GIT_REPO=${GIT_REPO}"  --build-arg "GIT_REF=${GIT_REF}" -t ruby-plugin-centos:latest -f ${WDIR}/Dockerfile.centos .
+  docker build --build-arg "ASSET_GEM=${GEM_NAME}" --build-arg "GIT_REPO=${GIT_REPO}"  --build-arg "GIT_REF=${GIT_REF}" -t ruby-plugin-centos:latest -f ${WDIR}/ruby-runtime/Dockerfile.centos .
   docker cp $(docker create --rm ruby-plugin-centos:latest sleep 0):/${GEM_NAME}.tar.gz ./dist/${GEM_NAME}_${TAG}_centos_linux_amd64.tar.gz
 
   # Generate the sha512sum for all the assets
@@ -40,7 +40,7 @@ if [ -d dist ]; then
   for filename in $files; do
     if [[ "$GITHUB_RELEASE_TAG" ]]; then
       echo "upload $filename"
-      bonsai/github-release-upload.sh github_api_token=$GITHUB_TOKEN repo_slug="$GIT_OWNER_REPO" tag="${GITHUB_RELEASE_TAG}" filename="$filename"
+      ${WDIR}/github-release-upload.sh github_api_token=$GITHUB_TOKEN repo_slug="$GIT_OWNER_REPO" tag="${GITHUB_RELEASE_TAG}" filename="$filename"
     fi
   done 
   file=$(basename "${files[0]}")
@@ -58,7 +58,7 @@ if [ -d dist ]; then
     cd ..
     if [[ "$GITHUB_RELEASE_TAG" ]]; then
       echo "upload ${sha512_file}"
-      bonsai/github-release-upload.sh github_api_token=$GITHUB_TOKEN repo_slug="$GIT_OWNER_REPO" tag="${GITHUB_RELEASE_TAG}" filename="dist/${sha512_file}"
+      ${WDIR}/github-release-upload.sh github_api_token=$GITHUB_TOKEN repo_slug="$GIT_OWNER_REPO" tag="${GITHUB_RELEASE_TAG}" filename="dist/${sha512_file}"
     fi
   fi
 

--- a/ruby-runtime/travis-build-ruby-plugin-assets.sh
+++ b/ruby-runtime/travis-build-ruby-plugin-assets.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-WDIR="bonsai/ruby-runtime/"
+[[ -z "$WDIR" ]] && { echo "WDIR is empty using bonsai/" ; WDIR="bonsai/"; }
 
 ##
 # TravisCI specific asset build script.
@@ -22,15 +22,15 @@ GIT_REF=${TRAVIS_COMMIT}
 
 if [ -d dist ]; then
   # Build Debian asset
-  docker build --build-arg "ASSET_GEM=${GEM_NAME}" --build-arg "GIT_REPO=${GIT_REPO}"  --build-arg "GIT_REF=${GIT_REF}" -t ruby-plugin-debian -f "${WDIR}/Dockerfile.debian" .
+  docker build --build-arg "ASSET_GEM=${GEM_NAME}" --build-arg "GIT_REPO=${GIT_REPO}"  --build-arg "GIT_REF=${GIT_REF}" -t ruby-plugin-debian -f "${WDIR}/ruby-runtime/Dockerfile.debian" .
   docker cp $(docker create --rm ruby-plugin-debian:latest sleep 0):/${GEM_NAME}.tar.gz ./dist/${GEM_NAME}_${TAG}_debian_linux_amd64.tar.gz
 
   # Build Alpine asset
-  docker build --build-arg "ASSET_GEM=${GEM_NAME}" --build-arg "GIT_REPO=${GIT_REPO}"  --build-arg "GIT_REF=${GIT_REF}" -t ruby-plugin-alpine:latest -f "${WDIR}/Dockerfile.alpine" .
+  docker build --build-arg "ASSET_GEM=${GEM_NAME}" --build-arg "GIT_REPO=${GIT_REPO}"  --build-arg "GIT_REF=${GIT_REF}" -t ruby-plugin-alpine:latest -f "${WDIR}/ruby-runtime/Dockerfile.alpine" .
   docker cp $(docker create --rm ruby-plugin-alpine:latest sleep 0):/${GEM_NAME}.tar.gz ./dist/${GEM_NAME}_${TAG}_alpine_linux_amd64.tar.gz
 
   # Build CentOS asset
-  docker build --build-arg "ASSET_GEM=${GEM_NAME}" --build-arg "GIT_REPO=${GIT_REPO}"  --build-arg "GIT_REF=${GIT_REF}" -t ruby-plugin-centos:latest -f "${WDIR}/Dockerfile.centos" .
+  docker build --build-arg "ASSET_GEM=${GEM_NAME}" --build-arg "GIT_REPO=${GIT_REPO}"  --build-arg "GIT_REF=${GIT_REF}" -t ruby-plugin-centos:latest -f "${WDIR}/ruby-runtime/Dockerfile.centos" .
   docker cp $(docker create --rm ruby-plugin-centos:latest sleep 0):/${GEM_NAME}.tar.gz ./dist/${GEM_NAME}_${TAG}_centos_linux_amd64.tar.gz
 
   # Generate the sha512sum for all the assets
@@ -39,7 +39,7 @@ if [ -d dist ]; then
   for filename in $files; do
     if [[ "$TRAVIS_TAG" ]]; then
       echo "upload $filename"
-      travis/github-release-upload.sh github_api_token=$GITHUB_TOKEN repo_slug="$TRAVIS_REPO_SLUG" tag="${TRAVIS_TAG}" filename="$filename"
+      ${WDIR}/github-release-upload.sh github_api_token=$GITHUB_TOKEN repo_slug="$TRAVIS_REPO_SLUG" tag="${TRAVIS_TAG}" filename="$filename"
     fi
   done 
   file=$(basename "${files[0]}")
@@ -57,7 +57,7 @@ if [ -d dist ]; then
     cd ..
     if [[ "$TRAVIS_TAG" ]]; then
       echo "upload ${sha512_file}"
-      travis/github-release-upload.sh github_api_token=$GITHUB_TOKEN repo_slug="$TRAVIS_REPO_SLUG" tag="${TRAVIS_TAG}" filename="dist/${sha512_file}"
+      ${WDIR}/github-release-upload.sh github_api_token=$GITHUB_TOKEN repo_slug="$TRAVIS_REPO_SLUG" tag="${TRAVIS_TAG}" filename="dist/${sha512_file}"
     fi
   fi
 

--- a/ruby-runtime/travis-build-ruby-plugin-assets.sh
+++ b/ruby-runtime/travis-build-ruby-plugin-assets.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+WDIR="bonsai/ruby-runtime/"
 
 ##
 # TravisCI specific asset build script.
@@ -21,15 +22,15 @@ GIT_REF=${TRAVIS_COMMIT}
 
 if [ -d dist ]; then
   # Build Debian asset
-  docker build --build-arg "ASSET_GEM=${GEM_NAME}" --build-arg "GIT_REPO=${GIT_REPO}"  --build-arg "GIT_REF=${GIT_REF}" -t ruby-plugin-debian -f Dockerfile.debian .
+  docker build --build-arg "ASSET_GEM=${GEM_NAME}" --build-arg "GIT_REPO=${GIT_REPO}"  --build-arg "GIT_REF=${GIT_REF}" -t ruby-plugin-debian -f "${WDIR}/Dockerfile.debian" .
   docker cp $(docker create --rm ruby-plugin-debian:latest sleep 0):/${GEM_NAME}.tar.gz ./dist/${GEM_NAME}_${TAG}_debian_linux_amd64.tar.gz
 
   # Build Alpine asset
-  docker build --build-arg "ASSET_GEM=${GEM_NAME}" --build-arg "GIT_REPO=${GIT_REPO}"  --build-arg "GIT_REF=${GIT_REF}" -t ruby-plugin-alpine:latest -f Dockerfile.alpine .
+  docker build --build-arg "ASSET_GEM=${GEM_NAME}" --build-arg "GIT_REPO=${GIT_REPO}"  --build-arg "GIT_REF=${GIT_REF}" -t ruby-plugin-alpine:latest -f "${WDIR}/Dockerfile.alpine" .
   docker cp $(docker create --rm ruby-plugin-alpine:latest sleep 0):/${GEM_NAME}.tar.gz ./dist/${GEM_NAME}_${TAG}_alpine_linux_amd64.tar.gz
 
   # Build CentOS asset
-  docker build --build-arg "ASSET_GEM=${GEM_NAME}" --build-arg "GIT_REPO=${GIT_REPO}"  --build-arg "GIT_REF=${GIT_REF}" -t ruby-plugin-centos:latest -f Dockerfile.centos .
+  docker build --build-arg "ASSET_GEM=${GEM_NAME}" --build-arg "GIT_REPO=${GIT_REPO}"  --build-arg "GIT_REF=${GIT_REF}" -t ruby-plugin-centos:latest -f "${WDIR}/Dockerfile.centos" .
   docker cp $(docker create --rm ruby-plugin-centos:latest sleep 0):/${GEM_NAME}.tar.gz ./dist/${GEM_NAME}_${TAG}_centos_linux_amd64.tar.gz
 
   # Generate the sha512sum for all the assets

--- a/ruby-runtime/travis-build-ruby-plugin-assets.sh
+++ b/ruby-runtime/travis-build-ruby-plugin-assets.sh
@@ -1,45 +1,44 @@
 #!/bin/bash
-##
-# General asset build script
-##
 
+##
+# TravisCI specific asset build script.
+#   Uses several TravisCI specific environment variables 
+##
 [[ -z "$GITHUB_TOKEN" ]] && { echo "GITHUB_TOKEN is empty" ; exit 1; }
 [[ -z "$1" ]] && { echo "Parameter 1, GEM_NAME is empty" ; exit 1; }
-[[ -z "$2" ]] && { echo "Parameter 2, GIT_OWNER_REPO is empty" ; exit 1; }
-[[ -z "$3" ]] && { echo "Parameter 3, GIT_REF is empty" ; exit 1; }
+[[ -z "$TRAVIS_REPO_SLUG" ]] && { echo "TRAVIS_REPO_SLUG is empty" ; exit 1; }
+[[ -z "$TRAVIS_COMMIT" ]] && { echo "TRAVIS_COMMIT is empty" ; exit 1; }
 
 GEM_NAME=$1
-GIT_OWNER_REPO=$2
-GIT_REF=$3
-GITHUB_RELEASE_TAG=$4
-TAG=$GITHUB_RELEASE_TAG
-[[ -z "$TAG" ]] && { echo "GITHUB_RELEASE_TAG is empty" ; TAG="0.0.1"; }
-echo $GEM_NAME $GIT_OWNER_REPO $TAG $GIT_REF
+TAG=$TRAVIS_TAG
+[[ -z "$TAG" ]] && { echo "TRAVIS_TAG is empty" ; TAG="0.0.1"; }
+echo $GEM_NAME $TRAVIS_REPO_SLUG $TAG $TRAVIS_COMMIT
 
 mkdir dist
-GIT_REPO="https://github.com/${GIT_OWNER_REPO}.git"
+GIT_REPO="https://github.com/${TRAVIS_REPO_SLUG}.git"
+GIT_REF=${TRAVIS_COMMIT}
 
 
 if [ -d dist ]; then
   # Build Debian asset
-  docker build --build-arg "ASSET_GEM=${GEM_NAME}" --build-arg "GIT_REPO=${GIT_REPO}"  --build-arg "GIT_REF=${GIT_REF}" -t ruby-plugin-debian -f bonsai/Dockerfile.debian .
+  docker build --build-arg "ASSET_GEM=${GEM_NAME}" --build-arg "GIT_REPO=${GIT_REPO}"  --build-arg "GIT_REF=${GIT_REF}" -t ruby-plugin-debian -f Dockerfile.debian .
   docker cp $(docker create --rm ruby-plugin-debian:latest sleep 0):/${GEM_NAME}.tar.gz ./dist/${GEM_NAME}_${TAG}_debian_linux_amd64.tar.gz
 
   # Build Alpine asset
-  docker build --build-arg "ASSET_GEM=${GEM_NAME}" --build-arg "GIT_REPO=${GIT_REPO}"  --build-arg "GIT_REF=${GIT_REF}" -t ruby-plugin-alpine:latest -f bonsai/Dockerfile.alpine .
+  docker build --build-arg "ASSET_GEM=${GEM_NAME}" --build-arg "GIT_REPO=${GIT_REPO}"  --build-arg "GIT_REF=${GIT_REF}" -t ruby-plugin-alpine:latest -f Dockerfile.alpine .
   docker cp $(docker create --rm ruby-plugin-alpine:latest sleep 0):/${GEM_NAME}.tar.gz ./dist/${GEM_NAME}_${TAG}_alpine_linux_amd64.tar.gz
 
   # Build CentOS asset
-  docker build --build-arg "ASSET_GEM=${GEM_NAME}" --build-arg "GIT_REPO=${GIT_REPO}"  --build-arg "GIT_REF=${GIT_REF}" -t ruby-plugin-centos:latest -f bonsai/Dockerfile.centos .
+  docker build --build-arg "ASSET_GEM=${GEM_NAME}" --build-arg "GIT_REPO=${GIT_REPO}"  --build-arg "GIT_REF=${GIT_REF}" -t ruby-plugin-centos:latest -f Dockerfile.centos .
   docker cp $(docker create --rm ruby-plugin-centos:latest sleep 0):/${GEM_NAME}.tar.gz ./dist/${GEM_NAME}_${TAG}_centos_linux_amd64.tar.gz
 
   # Generate the sha512sum for all the assets
   files=$( ls dist/*.tar.gz )
   echo $files
   for filename in $files; do
-    if [[ "$GITHUB_RELEASE_TAG" ]]; then
+    if [[ "$TRAVIS_TAG" ]]; then
       echo "upload $filename"
-      bonsai/github-release-upload.sh github_api_token=$GITHUB_TOKEN repo_slug="$GIT_OWNER_REPO" tag="${GITHUB_RELEASE_TAG}" filename="$filename"
+      travis/github-release-upload.sh github_api_token=$GITHUB_TOKEN repo_slug="$TRAVIS_REPO_SLUG" tag="${TRAVIS_TAG}" filename="$filename"
     fi
   done 
   file=$(basename "${files[0]}")
@@ -55,9 +54,9 @@ if [ -d dist ]; then
     echo ""
     cat "${sha512_file}"
     cd ..
-    if [[ "$GITHUB_RELEASE_TAG" ]]; then
+    if [[ "$TRAVIS_TAG" ]]; then
       echo "upload ${sha512_file}"
-      bonsai/github-release-upload.sh github_api_token=$GITHUB_TOKEN repo_slug="$GIT_OWNER_REPO" tag="${GITHUB_RELEASE_TAG}" filename="dist/${sha512_file}"
+      travis/github-release-upload.sh github_api_token=$GITHUB_TOKEN repo_slug="$TRAVIS_REPO_SLUG" tag="${TRAVIS_TAG}" filename="dist/${sha512_file}"
     fi
   fi
 


### PR DESCRIPTION
Prototyping some Bonsai related CI scripts that make use of ruby-runtime Docker images to generate ruby plugin assets.

Two different scripts to serve same purpose:
1. travisCI specific script that makes explicit use of travis environment variables. This script is meant to integrate easily sensu-plugins  travis configs as a drop-in addition with very little work.

2. general asset build script, that should work with other CI services other than travis.  This script does not make any assumptions about provided environment variables beyond the required GITHUB_TOKEN envvar.

High level overview of build scripts:
1) build asset tarballs using docker
2) generate sha512 checksum file
3) upload asset tarballs and checksum file into Github release