### PR TITLE
use platform_family as filter for deb and rhel

### DIFF
--- a/ruby-runtime/.bonsai.yml.example
+++ b/ruby-runtime/.bonsai.yml.example
@@ -8,7 +8,7 @@ builds:
   filter:
   -  "entity.system.os == 'linux'"
   -  "entity.system.arch == 'amd64'"
-  -  "entity.system.platform == 'debian'"
+  -  "entity.system.platform_family == 'debian'"
 - platform: "centos"
   arch: "amd64"
   asset_filename: "#{repo}_#{version}_centos_linux_amd64.tar.gz"
@@ -16,7 +16,7 @@ builds:
   filter:
   -  "entity.system.os == 'linux'"
   -  "entity.system.arch == 'amd64'"
-  -  "entity.system.platform == 'rhel'"
+  -  "entity.system.platform_family == 'rhel'"
 - platform: "alpine"
   arch: "amd64"
   asset_filename: "#{repo}_#{version}_alpine_linux_amd64.tar.gz"


### PR DESCRIPTION
Fix to make example bonsai.yml  work with centos and ubuntu without editting.